### PR TITLE
feat: add OpenCV inpainting option

### DIFF
--- a/src/app/api/translate_api.py
+++ b/src/app/api/translate_api.py
@@ -95,6 +95,7 @@ def translate_image():
         blend_edges = data.get('blend_edges', True)
         inpainting_strength = float(data.get('inpainting_strength', constants.DEFAULT_INPAINTING_STRENGTH))
         use_lama = data.get('use_lama', False)  # 添加LAMA修复选项
+        use_opencv = data.get('use_opencv', False)  # 新增OpenCV修复选项
         skip_translation = data.get('skip_translation', False)  # 跳过翻译参数
         skip_ocr = data.get('skip_ocr', False)  # 跳过OCR参数
         remove_only = data.get('remove_only', False)  # 新增：仅消除文字模式参数
@@ -200,6 +201,9 @@ def translate_image():
             else:
                 inpainting_method = 'lama'
                 logger.info("使用LAMA修复方式")
+        elif use_opencv:
+            inpainting_method = 'opencv'
+            logger.info("使用OpenCV修复方式")
         elif use_inpainting:
             inpainting_method = 'inpainting'
             logger.info("使用MI-GAN修复方式")
@@ -380,6 +384,7 @@ def re_render_image():
         text_direction = data.get('textDirection', constants.DEFAULT_TEXT_DIRECTION)
         use_inpainting = data.get('use_inpainting', False)
         use_lama = data.get('use_lama', False)  # 添加LAMA修复选项
+        use_opencv = data.get('use_opencv', False)
         blend_edges = data.get('blend_edges', True)  # 默认启用边缘融合
         inpainting_strength = float(data.get('inpainting_strength', constants.DEFAULT_INPAINTING_STRENGTH))  # 默认修复强度为1.0
         is_font_style_change = data.get('is_font_style_change', False)  # 是否仅是字体/字号修改
@@ -402,7 +407,7 @@ def re_render_image():
         logger_clean_data = "null" if clean_image_data is None else f"长度: {len(clean_image_data)}"
         logger_styles_data = "null" if all_bubble_styles is None else f"长度: {len(all_bubble_styles)}"
         logger.info(f"重新渲染参数: fontSize_str={fontSize_str}, autoFontSize={data.get('autoFontSize')}, textDirection={text_direction}, translated_text={logger_text_data}, bubble_coords={logger_bubble_data}, is_font_style_change={is_font_style_change}")
-        logger.info(f"传入的干净图片数据: {logger_clean_data}, 使用智能修复: {use_inpainting}, 使用LAMA修复: {use_lama}")
+        logger.info(f"传入的干净图片数据: {logger_clean_data}, 使用智能修复: {use_inpainting}, 使用LAMA修复: {use_lama}, 使用OpenCV修复: {use_opencv}")
         logger.info(f"所有气泡样式数据: {logger_styles_data}")
         
         # 新的检查逻辑:
@@ -558,6 +563,7 @@ def re_render_image():
             blend_edges=blend_edges,
             inpainting_strength=inpainting_strength,
             use_lama=use_lama,  # 传递LAMA修复选项
+            use_opencv=use_opencv,
             fill_color=data.get('fill_color', constants.DEFAULT_FILL_COLOR),  # 传递填充颜色，默认白色
             text_color=textColor,  # 传递文字颜色
             rotation_angle=rotationAngle,  # 传递旋转角度
@@ -603,6 +609,7 @@ def re_render_single_bubble():
         clean_image_data = data.get('clean_image', '')
         use_inpainting = data.get('use_inpainting', False)
         use_lama = data.get('use_lama', False)  # 添加LAMA修复选项
+        use_opencv = data.get('use_opencv', False)
         is_single_bubble_style = data.get('is_single_bubble_style', False)
         
         # 新增参数：文字颜色和旋转角度
@@ -632,7 +639,7 @@ def re_render_single_bubble():
         logger.info(f"气泡样式数量={len(all_bubble_styles)}")
         logger.info(f"原始图像数据长度={len(image_data) if image_data else 0}")
         logger.info(f"干净图像数据长度={len(clean_image_data) if clean_image_data else 0}")
-        logger.info(f"使用MI-GAN修复={use_inpainting}, 使用LAMA修复={use_lama}")
+        logger.info(f"使用MI-GAN修复={use_inpainting}, 使用LAMA修复={use_lama}, 使用OpenCV修复={use_opencv}")
         logger.info(f"单个气泡样式设置={is_single_bubble_style}")
         logger.info(f"文字颜色={text_color}, 旋转角度={rotation_angle}")
         
@@ -703,6 +710,7 @@ def re_render_single_bubble():
         clean_image_data = data.get('clean_image', '')
         use_inpainting = data.get('use_inpainting', False)
         use_lama = data.get('use_lama', False)  # 添加LAMA修复选项
+        use_opencv = data.get('use_opencv', False)
         is_single_bubble_style = data.get('is_single_bubble_style', False)
         
         logger.info(f"使用MI-GAN修复={use_inpainting}, 使用LAMA修复={use_lama}")
@@ -791,10 +799,10 @@ def re_render_single_bubble():
         try:
             logger.info("开始调用render_single_bubble函数...")
             rendered_image = render_single_bubble(
-                image, 
-                bubble_index, 
-                all_texts, 
-                bubble_coords, 
+                image,
+                bubble_index,
+                all_texts,
+                bubble_coords,
                 fontSize,
                 corrected_font_path,
                 text_direction,
@@ -804,7 +812,8 @@ def re_render_single_bubble():
                 text_color,          # 文字颜色参数
                 rotation_angle,      # 旋转角度参数
                 use_lama,           # LAMA修复选项
-                data.get('fill_color', constants.DEFAULT_FILL_COLOR) # 填充颜色参数
+                use_opencv=use_opencv,
+                fill_color=data.get('fill_color', constants.DEFAULT_FILL_COLOR)
             )
             logger.info("成功调用render_single_bubble函数，获得渲染结果")
             
@@ -969,6 +978,7 @@ def apply_settings_to_all_images():
                     blend_edges=True,
                     inpainting_strength=constants.DEFAULT_INPAINTING_STRENGTH,
                     use_lama=use_lama,  # 传递LAMA修复选项
+                    use_opencv=use_opencv,
                     fill_color=data.get('fill_color', constants.DEFAULT_FILL_COLOR),  # 使用文字颜色作为填充颜色
                     text_color=textColor,  # 传递文字颜色
                     rotation_angle=rotationAngle,  # 传递旋转角度

--- a/src/app/static/js/high_quality_translation.js
+++ b/src/app/static/js/high_quality_translation.js
@@ -155,6 +155,7 @@ async function removeAllImagesText() {
         const repairSettings = ui.getRepairSettings();
         const useInpainting = repairSettings.useInpainting;
         const useLama = repairSettings.useLama;
+        const useOpenCV = repairSettings.useOpenCV;
         const blendEdges = state.blendEdges !== undefined ? state.blendEdges : $('#blendEdges').prop('checked');
         const inpaintingStrength = state.inpaintingStrength !== undefined ? state.inpaintingStrength : parseFloat($('#inpaintingStrength').val());
         const fillColor = state.defaultFillColor;
@@ -207,7 +208,8 @@ async function removeAllImagesText() {
             const imageData = state.images[currentIndex];
             
             // 添加日志，显示当前使用的修复方式
-            console.log(`高质量翻译-消除文字[${currentIndex + 1}/${totalImages}]: 使用修复方式: ${useLama ? 'LAMA' : (useInpainting ? 'MI-GAN' : '纯色填充')}`);
+            const methodName = useLama ? 'LAMA' : (useInpainting ? 'MI-GAN' : (useOpenCV ? 'OpenCV' : '纯色填充'));
+            console.log(`高质量翻译-消除文字[${currentIndex + 1}/${totalImages}]: 使用修复方式: ${methodName}`);
             
             // 准备API请求参数
             const params = {
@@ -220,6 +222,7 @@ async function removeAllImagesText() {
                 textDirection: textDirection,
                 use_inpainting: useInpainting,
                 use_lama: useLama,
+                use_opencv: useOpenCV,
                 blend_edges: blendEdges,
                 inpainting_strength: inpaintingStrength,
                 fill_color: fillColor,

--- a/src/app/static/js/labeling_mode.js
+++ b/src/app/static/js/labeling_mode.js
@@ -901,7 +901,9 @@ export function handleUseManualBoxesClick() {
         layout_direction: $('#layoutDirection').val(),
         text_color: $('#textColor').val(),
         fill_color: $('#fillColor').val(),
-        use_inpainting: $('#useInpainting').val(),
+        use_inpainting: $('#useInpainting').val() === 'true',
+        use_lama: $('#useInpainting').val() === 'lama',
+        use_opencv: $('#useInpainting').val() === 'opencv',
         ocr_engine: $('#ocrEngine').val(),
         provided_coords: state.manualBubbleCoords // 手动标注的坐标
     };

--- a/src/app/static/js/main.js
+++ b/src/app/static/js/main.js
@@ -851,6 +851,7 @@ export function translateCurrentImage() {
     ui.showTranslatingIndicator(state.currentImageIndex);
 
     const repairSettings = ui.getRepairSettings();
+    const useOpenCV = repairSettings.useOpenCV;
     const isAutoFontSize = $('#autoFontSize').is(':checked');
     const fontSize = isAutoFontSize ? 'auto' : $('#fontSize').val();
     const ocr_engine = $('#ocrEngine').val();
@@ -884,6 +885,7 @@ export function translateCurrentImage() {
         textbox_prompt_content: $('#textboxPromptContent').val(),
         use_inpainting: repairSettings.useInpainting,
         use_lama: repairSettings.useLama,
+        use_opencv: useOpenCV,
         blend_edges: $('#blendEdges').prop('checked'),
         inpainting_strength: parseFloat($('#inpaintingStrength').val()),
         fill_color: $('#fillColor').val(),
@@ -1064,6 +1066,8 @@ export function translateAllImages() {
     const repairSettings = ui.getRepairSettings(); // ui.js 获取修复设置
     const useInpainting = repairSettings.useInpainting;
     const useLama = repairSettings.useLama;
+    const useOpenCV = repairSettings.useOpenCV;
+    const useOpenCV = repairSettings.useOpenCV;
     const inpaintingStrength = parseFloat($('#inpaintingStrength').val());
     const blendEdges = $('#blendEdges').prop('checked');
     const promptContent = $('#promptContent').val();
@@ -1184,7 +1188,7 @@ export function translateAllImages() {
             fontFamily: fontFamily, textDirection: textDirection,
             prompt_content: promptContent, use_textbox_prompt: useTextboxPrompt,
             textbox_prompt_content: textboxPromptContent, use_inpainting: useInpainting,
-            use_lama: useLama, blend_edges: blendEdges, inpainting_strength: inpaintingStrength,
+            use_lama: useLama, use_opencv: useOpenCV, blend_edges: blendEdges, inpainting_strength: inpaintingStrength,
             fill_color: fillColor,
             text_color: textColor,
             rotation_angle: rotationAngle,
@@ -1940,7 +1944,8 @@ export function removeAllBubblesText() {
             use_textbox_prompt: false,
             textbox_prompt_content: '',
             use_inpainting: useInpainting,
-            use_lama: useLama, 
+            use_lama: useLama,
+            use_opencv: useOpenCV,
             blend_edges: blendEdges, 
             inpainting_strength: inpaintingStrength,
             fill_color: fillColor,

--- a/src/app/static/js/ui.js
+++ b/src/app/static/js/ui.js
@@ -1006,14 +1006,15 @@ export function hideTranslatingIndicator(index) {
 
 /**
  * 获取当前选择的气泡填充/修复方式设置
- * @returns {{useInpainting: boolean, useLama: boolean}}
- */
+ * @returns {{useInpainting: boolean, useLama: boolean, useOpenCV: boolean}}
+*/
 export function getRepairSettings() {
     const repairMethod = $('#useInpainting').val(); // 在函数内获取元素
     // console.log("获取修复设置:", repairMethod); // 可以取消注释用于调试
     return {
         useInpainting: repairMethod === 'true', // MI-GAN
-        useLama: repairMethod === 'lama'      // LAMA
+        useLama: repairMethod === 'lama',      // LAMA
+        useOpenCV: repairMethod === 'opencv'   // OpenCV
     };
 }
 

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -233,6 +233,7 @@
                                 <select id="useInpainting">
                                     <option value="false" selected>纯色填充</option>
                                     <option value="lama">LAMA修复</option>
+                                    <option value="opencv">OpenCV修复</option>
                                 </select>
                             </div>
                             <div id="solidColorOptions">

--- a/src/core/processing.py
+++ b/src/core/processing.py
@@ -36,7 +36,7 @@ def process_image_translation(
     prompt_content='',
     use_textbox_prompt=False,
     textbox_prompt_content='',
-    inpainting_method='solid', # 'solid', 'lama'
+    inpainting_method='solid', # 'solid', 'lama', 'opencv'
     fill_color='#ffffff',
     migan_strength=1.0,
     migan_blend_edges=True,
@@ -92,7 +92,7 @@ def process_image_translation(
         prompt_content (str): 自定义翻译提示词内容
         use_textbox_prompt (bool): 是否使用专为文本框优化的提示词
         textbox_prompt_content (str): 文本框翻译的提示词内容
-        inpainting_method (str): 气泡内容擦除方法，可选'solid'(纯色填充)或'lama'(AI修复)
+        inpainting_method (str): 气泡内容擦除方法，可选'solid'(纯色填充)、'lama'(AI修复)或'opencv'(OpenCV修复)
         fill_color (str): 气泡填充颜色，格式为十六进制RGB如'#ffffff'
         migan_strength (float): MIGAN修复强度，范围0.0-1.0
         migan_blend_edges (bool): 是否对MIGAN修复结果的边缘进行混合
@@ -134,6 +134,9 @@ def process_image_translation(
         注意: 如果处理失败，processed_image将是原始图像的副本。
     """
     logger.info(f"开始处理图像翻译流程: 源={source_language}, 目标={target_language}, 修复={inpainting_method}")
+    if inpainting_method not in ['solid', 'lama', 'opencv']:
+        logger.warning(f"未知的修复方法 {inpainting_method}，回退到纯色填充")
+        inpainting_method = 'solid'
     start_time_total = time.time() # 记录总时间
 
     original_image_copy = image_pil.copy() # 保留原始副本以备失败时返回

--- a/src/core/rendering.py
+++ b/src/core/rendering.py
@@ -610,6 +610,7 @@ def render_single_bubble(
     text_color=constants.DEFAULT_TEXT_COLOR,
     rotation_angle=constants.DEFAULT_ROTATION_ANGLE,
     use_lama=False,
+    use_opencv=False,
     fill_color=constants.DEFAULT_FILL_COLOR,
     # 新增描边参数 (这些应来自前端对单个气泡的设置，或全局设置)
     enable_stroke_param=False,
@@ -645,7 +646,10 @@ def render_single_bubble(
         # from src.interfaces.migan_interface import is_migan_available
         
         inpainting_method = 'solid'
-        if use_lama and is_lama_available(): inpainting_method = 'lama'
+        if use_lama and is_lama_available():
+            inpainting_method = 'lama'
+        elif use_opencv:
+            inpainting_method = 'opencv'
         # elif use_inpainting and is_migan_available(): inpainting_method = 'migan'
         img_pil, generated_clean_bg = inpaint_bubbles(
             image, target_coords, method=inpainting_method, fill_color=fill_color
@@ -755,6 +759,7 @@ def re_render_text_in_bubbles(
     blend_edges=True,
     inpainting_strength=constants.DEFAULT_INPAINTING_STRENGTH,
     use_lama=False,
+    use_opencv=False,
     fill_color=constants.DEFAULT_FILL_COLOR,
     text_color=constants.DEFAULT_TEXT_COLOR,
     rotation_angle=constants.DEFAULT_ROTATION_ANGLE,
@@ -794,7 +799,10 @@ def re_render_text_in_bubbles(
         # from src.interfaces.migan_interface import is_migan_available
         
         inpainting_method = 'solid'
-        if use_lama and is_lama_available(): inpainting_method = 'lama'
+        if use_lama and is_lama_available():
+            inpainting_method = 'lama'
+        elif use_opencv:
+            inpainting_method = 'opencv'
         # elif use_inpainting and is_migan_available(): inpainting_method = 'migan'
 
         logger.info(f"重渲染时选择修复/填充方法: {inpainting_method}")


### PR DESCRIPTION
## Summary
- add OpenCV-based bubble inpainting method
- allow `opencv` in processing pipeline and front-end settings
- wire OpenCV option through API and rendering helpers

## Testing
- `pytest` *(fails: UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0)*

------
https://chatgpt.com/codex/tasks/task_e_68ad6df67178832d8e2247d6e594ccd7